### PR TITLE
Update to latest gwt-dom, gwt-aria, gwt-animation versions

### DIFF
--- a/gwt-layout-j2cl-tests/pom.xml
+++ b/gwt-layout-j2cl-tests/pom.xml
@@ -14,12 +14,9 @@
   <description>Test cases for the J2Cl tests</description>
 
   <properties>
-    <maven.j2cl.plugin>0.16-SNAPSHOT</maven.j2cl.plugin>
+    <maven.j2cl.plugin>0.19</maven.j2cl.plugin>
 
-    <!-- CI -->
-    <vertispan.j2cl.repo.url>https://repo.vertispan.com/j2cl/</vertispan.j2cl.repo.url>
-
-    <j2cl.version>0.8-SNAPSHOT</j2cl.version>
+    <j2cl.version>0.10.0-3c97afeac</j2cl.version>
   </properties>
 
   <dependencies>
@@ -121,20 +118,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>vertispan-snapshots</id>
-      <name>Vertispan hosted artifacts-releases</name>
-      <url>${vertispan.j2cl.repo.url}</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>vertispan-releases</id>
-      <name>Vertispan hosted artifacts-releases</name>
-      <url>${vertispan.j2cl.repo.url}</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@
     <maven.license.plugin>3.0</maven.license.plugin>
     <maven.surfire.plugin>3.0.0-M1</maven.surfire.plugin>
 
-    <gwt.aria.version>1.0.0-RC1</gwt.aria.version>
-    <gwt.animation.version>1.0.0-RC1</gwt.animation.version>
+    <gwt.aria.version>1.0.0-RC2</gwt.aria.version>
+    <gwt.animation.version>1.0.0-RC2</gwt.animation.version>
     <gwt.regexp.version>1.0.0-RC1</gwt.regexp.version>
-    <gwt.dom.version>1.0.0-RC1</gwt.dom.version>
+    <gwt.dom.version>1.0.0-RC2</gwt.dom.version>
     <gwt.dom.style.definitions.version>1.0.0-RC1</gwt.dom.style.definitions.version>
 
     <elemental2.version>1.1.0</elemental2.version>


### PR DESCRIPTION
This fixes compatibility with j2cl. This merge also updates to the
latest j2cl-maven-plugin version, and removes unnecessary repository
tags, now that we are using a release build.